### PR TITLE
Histograms are now reset on mutation

### DIFF
--- a/source/AagosOrg.h
+++ b/source/AagosOrg.h
@@ -66,6 +66,11 @@ public:
   // getter for number of bins in histogram
   const size_t GetNumBins() { return num_bins; }
 
+  void ResetHistogram() {
+    histogram.Reset();
+    initialized = false;
+  }
+
   // randomizes genome and gene starts
   void Randomize(emp::Random &random)
   {

--- a/source/AagosWorld.h
+++ b/source/AagosWorld.h
@@ -191,6 +191,10 @@ public:
                 x--;
           }
 
+          int num_muts = num_moves + num_flips + num_insert + num_delete;
+          if (num_muts > 0) {
+            org.ResetHistogram();
+          }
           return num_moves + num_flips + num_insert + num_delete; // Returns total num mutations
         };
     SetMutFun(mut_fun);       // set mutation function of world to above


### PR DESCRIPTION
This branch fixes the issue with the histograms not being correctly calculated for all organisms but the first generation ones. To circumvent the copy constructor used in the `DoBirth` function, each organism's histogram is rebuilt on mutation so it reflects its gene size, not its parent's.